### PR TITLE
Replace "id" with "ID"

### DIFF
--- a/.changeset/great-walls-look.md
+++ b/.changeset/great-walls-look.md
@@ -1,0 +1,5 @@
+---
+'react-json-friendly-viewer': minor
+---
+
+Replace "id" with "ID"

--- a/packages/react-json-friendly-viewer/src/lib/prettify-label.ts
+++ b/packages/react-json-friendly-viewer/src/lib/prettify-label.ts
@@ -24,6 +24,9 @@ export const prettifyLabel = (camelCaseText: string): string => {
 		// Note: the next two regexes use {2,} instead of + to add space on phrases like Room26A and 26ABCs but not on phrases like R2D2 and C3PO"
 		.replace(/([A-Z]{2,})([0-9]{2,})/g, '$1 $2') // "To Get Your GED In Time A Song About The 26ABCs Is Of The Essence But A Personal ID Card For User 456 In Room 26A Containing ABC 26 Times Is Not As Easy As 123 For C3PO Or R2D2 Or 2R2D"
 		.replace(/([0-9]{2,})([A-Z]{2,})/g, '$1 $2')
+
+		// Note: this replaces the word "id" (case-insensitive) with "ID"
+		.replace(/\bid\b/ig, 'ID')
 		.trim();
 	return (
 		sentence &&


### PR DESCRIPTION
Problem: currently if we passed in `tradeId`, the result would be `Trade Id`, but ideally it should be `Trade ID`.

This PR adds a line to replace the word `id` (case-insensitive) with `ID`. Only full words will be replaced, `id` that is part of a word will not be replaced.

![Screenshot 2023-07-27 at 3 29 53 PM](https://github.com/malcolm-kee/react-json-friendly-viewer/assets/113886822/1377d0c5-9f36-43d1-b159-6cb401309d54)
